### PR TITLE
업데이트된 유저 정보 UI 반영되지 않는 에러 해결, 코치 또는 학생 기준 홈에서의 UI 차별화 및 기능 차별화

### DIFF
--- a/VoQal_iOS.xcodeproj/project.pbxproj
+++ b/VoQal_iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		954E1DF52C3FD4F4007D72B4 /* CoachSelectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954E1DF42C3FD4F4007D72B4 /* CoachSelectionData.swift */; };
 		954E1DF72C3FD50C007D72B4 /* CoachSelectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954E1DF62C3FD50C007D72B4 /* CoachSelectionModel.swift */; };
 		954F56962BD0AF8400288A7D /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F56952BD0AF8400288A7D /* Extension.swift */; };
+		95715A9F2C4673130010D4B7 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95715A9E2C4673130010D4B7 /* UserModel.swift */; };
+		95715AA02C4678020010D4B7 /* Fonts in Resources */ = {isa = PBXBuildFile; fileRef = 9542B63B2BCD688E0060E1BB /* Fonts */; };
+		95715AA12C4678030010D4B7 /* Fonts in Resources */ = {isa = PBXBuildFile; fileRef = 9542B63B2BCD688E0060E1BB /* Fonts */; };
 		95786E8C2C40210B00F77146 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95786E8B2C40210B00F77146 /* KeychainHelper.swift */; };
 		95786E8E2C40233800F77146 /* LoginData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95786E8D2C40233800F77146 /* LoginData.swift */; };
 		95786E902C40234100F77146 /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95786E8F2C40234100F77146 /* LoginModel.swift */; };
@@ -38,6 +41,9 @@
 		957E3E152C344DD800936617 /* EmailVerifyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E3E142C344DD800936617 /* EmailVerifyModel.swift */; };
 		957E3E172C344DE500936617 /* NicknameVerifyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E3E162C344DE500936617 /* NicknameVerifyModel.swift */; };
 		957E3E192C344E0100936617 /* PasswordResetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E3E182C344E0100936617 /* PasswordResetModel.swift */; };
+		9587DDF32C46BA880039B6D0 /* CustomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9587DDF22C46BA880039B6D0 /* CustomButtonView.swift */; };
+		9587DDF72C46C43D0039B6D0 /* ManageStudentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9587DDF62C46C43D0039B6D0 /* ManageStudentViewController.swift */; };
+		9587DDFB2C46C4670039B6D0 /* ManageStudentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9587DDFA2C46C4670039B6D0 /* ManageStudentView.swift */; };
 		958D42452C37DDEC00088EA3 /* ValidationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958D42442C37DDEC00088EA3 /* ValidationUtility.swift */; };
 		958FE7C42C42AE7F00F2954D /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958FE7C32C42AE7F00F2954D /* BaseViewController.swift */; };
 		958FE7C72C42C2BB00F2954D /* HomeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958FE7C62C42C2BB00F2954D /* HomeManager.swift */; };
@@ -130,7 +136,7 @@
 		9541D37B2BD2AFC200B36977 /* ChallengeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewController.swift; sourceTree = "<group>"; };
 		9541D37E2BD2AFD900B36977 /* ChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeView.swift; sourceTree = "<group>"; };
 		9541D3812BD2AFEE00B36977 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
-		9542B63B2BCD688E0060E1BB /* Fonts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Fonts; path = VoQal_iOS/Fonts; sourceTree = "<group>"; };
+		9542B63B2BCD688E0060E1BB /* Fonts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; path = Fonts; sourceTree = "<group>"; };
 		9542B63E2BCD6BEB0060E1BB /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		9542B6412BCD6C470060E1BB /* RegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewController.swift; sourceTree = "<group>"; };
 		9542B6472BCD7FE40060E1BB /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -139,6 +145,7 @@
 		954E1DF42C3FD4F4007D72B4 /* CoachSelectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachSelectionData.swift; sourceTree = "<group>"; };
 		954E1DF62C3FD50C007D72B4 /* CoachSelectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachSelectionModel.swift; sourceTree = "<group>"; };
 		954F56952BD0AF8400288A7D /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
+		95715A9E2C4673130010D4B7 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		95786E8B2C40210B00F77146 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		95786E8D2C40233800F77146 /* LoginData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginData.swift; sourceTree = "<group>"; };
 		95786E8F2C40234100F77146 /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
@@ -148,6 +155,9 @@
 		957E3E142C344DD800936617 /* EmailVerifyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerifyModel.swift; sourceTree = "<group>"; };
 		957E3E162C344DE500936617 /* NicknameVerifyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameVerifyModel.swift; sourceTree = "<group>"; };
 		957E3E182C344E0100936617 /* PasswordResetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordResetModel.swift; sourceTree = "<group>"; };
+		9587DDF22C46BA880039B6D0 /* CustomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButtonView.swift; sourceTree = "<group>"; };
+		9587DDF62C46C43D0039B6D0 /* ManageStudentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageStudentViewController.swift; sourceTree = "<group>"; };
+		9587DDFA2C46C4670039B6D0 /* ManageStudentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageStudentView.swift; sourceTree = "<group>"; };
 		958D42442C37DDEC00088EA3 /* ValidationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationUtility.swift; sourceTree = "<group>"; };
 		958FE7C32C42AE7F00F2954D /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		958FE7C62C42C2BB00F2954D /* HomeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeManager.swift; sourceTree = "<group>"; };
@@ -238,6 +248,8 @@
 		9541D32E2BD29BF300B36977 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				9587DDF92C46C4590039B6D0 /* Student */,
+				9587DDF82C46C4530039B6D0 /* Coach */,
 				9541D32F2BD29C0300B36977 /* HomeView.swift */,
 			);
 			path = Home;
@@ -246,6 +258,8 @@
 		9541D3312BD29CB800B36977 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				9587DDF52C46C4150039B6D0 /* Student */,
+				9587DDF42C46C3FC0039B6D0 /* Coach */,
 				9541D3322BD29CCA00B36977 /* HomeViewController.swift */,
 			);
 			path = Home;
@@ -338,6 +352,7 @@
 				958FE7C82C42C31500F2954D /* Home */,
 				959B57572C412BF3009428D7 /* Auth */,
 				959D94272C2C77B00014F086 /* Onboarding */,
+				95715A9E2C4673130010D4B7 /* UserModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -374,6 +389,36 @@
 				957E3E162C344DE500936617 /* NicknameVerifyModel.swift */,
 			);
 			path = Verification;
+			sourceTree = "<group>";
+		};
+		9587DDF42C46C3FC0039B6D0 /* Coach */ = {
+			isa = PBXGroup;
+			children = (
+				9587DDF62C46C43D0039B6D0 /* ManageStudentViewController.swift */,
+			);
+			path = Coach;
+			sourceTree = "<group>";
+		};
+		9587DDF52C46C4150039B6D0 /* Student */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Student;
+			sourceTree = "<group>";
+		};
+		9587DDF82C46C4530039B6D0 /* Coach */ = {
+			isa = PBXGroup;
+			children = (
+				9587DDFA2C46C4670039B6D0 /* ManageStudentView.swift */,
+			);
+			path = Coach;
+			sourceTree = "<group>";
+		};
+		9587DDF92C46C4590039B6D0 /* Student */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Student;
 			sourceTree = "<group>";
 		};
 		958FE7C52C42C2AC00F2954D /* Home */ = {
@@ -500,7 +545,6 @@
 		95B5C6602BCABE490067432A = {
 			isa = PBXGroup;
 			children = (
-				9542B63B2BCD688E0060E1BB /* Fonts */,
 				95B5C66B2BCABE490067432A /* VoQal_iOS */,
 				95B5C6822BCABE4B0067432A /* VoQal_iOSTests */,
 				95B5C68C2BCABE4B0067432A /* VoQal_iOSUITests */,
@@ -523,6 +567,7 @@
 		95B5C66B2BCABE490067432A /* VoQal_iOS */ = {
 			isa = PBXGroup;
 			children = (
+				9542B63B2BCD688E0060E1BB /* Fonts */,
 				95B661692C3D30850091F241 /* Components */,
 				954F56942BD0AF2600288A7D /* Resources */,
 				9542B6442BCD7F910060E1BB /* Models */,
@@ -559,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				95B6616A2C3D309F0091F241 /* RoleSelectionButton.swift */,
+				9587DDF22C46BA880039B6D0 /* CustomButtonView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -693,6 +739,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95715AA02C4678020010D4B7 /* Fonts in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -700,6 +747,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95715AA12C4678030010D4B7 /* Fonts in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -846,7 +894,9 @@
 				95786E902C40234100F77146 /* LoginModel.swift in Sources */,
 				9541D3712BD2ACC400B36977 /* SceneDelegate.swift in Sources */,
 				95A0D4422C43AD8E002A768B /* MyPageView.swift in Sources */,
+				9587DDF72C46C43D0039B6D0 /* ManageStudentViewController.swift in Sources */,
 				954E1DF72C3FD50C007D72B4 /* CoachSelectionModel.swift in Sources */,
+				9587DDFB2C46C4670039B6D0 /* ManageStudentView.swift in Sources */,
 				959D943D2C2EF7520014F086 /* EmailFinderModel.swift in Sources */,
 				9541D3332BD29CCA00B36977 /* HomeViewController.swift in Sources */,
 				957E3E192C344E0100936617 /* PasswordResetModel.swift in Sources */,
@@ -856,11 +906,13 @@
 				95B661682C3D1D370091F241 /* RoleSelectionView.swift in Sources */,
 				9541D3302BD29C0300B36977 /* HomeView.swift in Sources */,
 				959D942B2C2C7A800014F086 /* RegistrationData.swift in Sources */,
+				95715A9F2C4673130010D4B7 /* UserModel.swift in Sources */,
 				959B57592C412C02009428D7 /* AuthManager.swift in Sources */,
 				95B661602C3D1C390091F241 /* RoleSelectionModel.swift in Sources */,
 				95B661622C3D1C5F0091F241 /* RoleSelectionData.swift in Sources */,
 				959B57562C41268D009428D7 /* AuthInterceptor.swift in Sources */,
 				959D94292C2C7A650014F086 /* RegistrationModel.swift in Sources */,
+				9587DDF32C46BA880039B6D0 /* CustomButtonView.swift in Sources */,
 				959D94212C2AEF100014F086 /* RegistrationManager.swift in Sources */,
 				957E3E102C344D0600936617 /* EmailVerifyData.swift in Sources */,
 				95B6616B2C3D309F0091F241 /* RoleSelectionButton.swift in Sources */,

--- a/VoQal_iOS/Components/CustomButtonView.swift
+++ b/VoQal_iOS/Components/CustomButtonView.swift
@@ -1,0 +1,68 @@
+//
+//  CustomButtonView.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 7/16/24.
+//
+
+import UIKit
+
+class CustomButtonView: UIView {
+    
+    private let button: UIButton = {
+        let button = UIButton()
+        button.layer.cornerRadius = 10.0
+        button.tintColor = .white
+        button.backgroundColor = UIColor(named: "bottomBarColor")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = UIFont(name: "SUIT-Regular", size: 11)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupUI() {
+        addSubview(button)
+        addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            button.topAnchor.constraint(equalTo: topAnchor),
+            button.leadingAnchor.constraint(equalTo: leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
+            label.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 8),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
+        button.addTarget(target, action: action, for: controlEvents)
+    }
+    
+    func setIcon(_ icon: UIImage) {
+        button.setImage(icon, for: .normal)
+    }
+    
+    func setTitleLabel(_ title: String) {
+        label.text = title
+    }
+    
+    
+}

--- a/VoQal_iOS/Controllers/Home/Coach/ManageStudentViewController.swift
+++ b/VoQal_iOS/Controllers/Home/Coach/ManageStudentViewController.swift
@@ -1,0 +1,28 @@
+//
+//  ManageStudentViewController.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 7/17/24.
+//
+
+import UIKit
+
+class ManageStudentViewController: BaseViewController {
+
+    private let manageStudentView = ManageStudentView()
+    
+    override func loadView() {
+        view = manageStudentView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        
+    }
+    
+    override func setAddTarget() {
+        
+    }
+    
+}

--- a/VoQal_iOS/Controllers/Home/HomeViewController.swift
+++ b/VoQal_iOS/Controllers/Home/HomeViewController.swift
@@ -7,14 +7,6 @@
 
 import UIKit
 
-struct UserModel: Codable, Equatable {
-    let email: String?
-    let nickname: String?
-    let name: String?
-    let phoneNum: String?
-    let role: String?
-}
-
 class HomeViewController: BaseViewController {
     private let homeView = HomeView()
     private let homeManager = HomeManager()
@@ -28,7 +20,8 @@ class HomeViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         print("home viewDidLoad!")
-        
+        homeView.homeViewController = self
+        setupNavigationBar()
         NotificationCenter.default.addObserver(self, selector: #selector(userModelUpdated), name: .userModelUpdated, object: nil)
         print("Notification observer registered")
     }
@@ -39,9 +32,10 @@ class HomeViewController: BaseViewController {
         
         DispatchQueue.main.async {
             self.updateUserInformationIfNeeded()
+            
+            self.refreshUI()
         }
         
-        refreshUI()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -50,6 +44,11 @@ class HomeViewController: BaseViewController {
         // Observer 제거하지 않음
         // NotificationCenter.default.removeObserver(self, name: .userModelUpdated, object: nil)
         print("Notification observer will not be removed")
+    }
+    
+    private func setupNavigationBar() {
+        self.navigationController?.navigationBar.topItem?.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        
     }
     
     override func showLoginScreen() {
@@ -137,15 +136,21 @@ class HomeViewController: BaseViewController {
         if currentUser != user {
             print("Updating UI with new user")
             currentUser = user
-            updateUI(with: user)
+            homeView.updateUI(with: user)
         } else {
             print("No need to update UI - user is the same")
         }
     }
 
-    private func updateUI(with user: UserModel) {
-        // 유저 정보를 사용하여 UI를 업데이트합니다.
-        // 예: homeView.nicknameLabel.text = user.nickname
-        print("update UI with user: \(user)")
+    @objc internal func didTapManageStudentBtn() {
+        print("학생 관리 탭!")
+        let vc = ManageStudentViewController()
+        navigationController?.pushViewController(vc, animated: true)
+        vc.title = "학생 관리"
     }
+    
+    @objc internal func didTapManageLessonBtn() {
+        print("수업 관리 탭!")
+    }
+    
 }

--- a/VoQal_iOS/Info.plist
+++ b/VoQal_iOS/Info.plist
@@ -6,16 +6,16 @@
 	<string>Dark</string>
 	<key>UIAppFonts</key>
 	<array>
-		<string>SUIT-Bold.otf</string>
-		<string>SUIT-ExtraBold.otf</string>
-		<string>SUIT-ExtraLight.otf</string>
-		<string>SUIT-Heavy.otf</string>
-		<string>SUIT-Light.otf</string>
-		<string>SUIT-Medium.otf</string>
-		<string>SUIT-Regular.otf</string>
-		<string>SUIT-SemiBold.otf</string>
-		<string>SUIT-Thin.otf</string>
-	</array>
+		<string>Fonts/SUIT-Regular.otf</string>
+    	<string>Fonts/SUIT-Bold.otf</string>
+    	<string>Fonts/SUIT-ExtraBold.otf</string>
+    	<string>Fonts/SUIT-ExtraLight.otf</string>
+    	<string>Fonts/SUIT-Heavy.otf</string>
+   	 	<string>Fonts/SUIT-Light.otf</string>
+   	 	<string>Fonts/SUIT-Medium.otf</string>
+    	<string>Fonts/SUIT-SemiBold.otf</string>
+    	<string>Fonts/SUIT-Thin.otf</string>
+		</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/VoQal_iOS/Models/UserModel.swift
+++ b/VoQal_iOS/Models/UserModel.swift
@@ -1,0 +1,18 @@
+//
+//  UserModel.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 7/16/24.
+//
+
+import Foundation
+
+struct UserModel: Codable, Equatable {
+    let email: String?
+    let nickname: String?
+    let name: String?
+    let phoneNum: String?
+    let role: String?
+}
+
+

--- a/VoQal_iOS/Views/Home/Coach/ManageStudentView.swift
+++ b/VoQal_iOS/Views/Home/Coach/ManageStudentView.swift
@@ -1,0 +1,27 @@
+//
+//  ManageStudentView.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 7/17/24.
+//
+
+import UIKit
+
+class ManageStudentView: BaseView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func addSubViews() {
+        
+    }
+    
+    override func setConstraints() {
+        
+    }
+}

--- a/VoQal_iOS/Views/Home/HomeView.swift
+++ b/VoQal_iOS/Views/Home/HomeView.swift
@@ -9,30 +9,106 @@ import UIKit
 
 class HomeView: BaseView {
     
-    let userModel: UserModel?
+    weak var homeViewController: HomeViewController?
+    
+    private let manageRequestButton: CustomButtonView = {
+        let customButtonView = CustomButtonView()
+        customButtonView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return customButtonView
+    }()
     
     private let introLabel: UILabel = {
         let label = UILabel()
-//        label.text = "\(userModel.name)님 "
+        label.textColor = .white
+        label.font = UIFont(name: "SUIT-Regular", size: 25)
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
     }()
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    override func addSubViews() {
+    
+    func updateUI(with user: UserModel) {
         
+        setIntroText(user.name)
+        configureButton(user.role)
+        
+        
+    }
+    
+    override func addSubViews() {
+        addSubview(introLabel)
+        addSubview(manageRequestButton)
     }
     
     override func setConstraints() {
         
+        NSLayoutConstraint.activate([
+            introLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            introLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 50),
+            introLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 40),
+            introLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -40),
+            
+            manageRequestButton.topAnchor.constraint(equalTo: introLabel.bottomAnchor, constant: 50),
+            manageRequestButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            manageRequestButton.widthAnchor.constraint(equalToConstant: 58),
+            manageRequestButton.heightAnchor.constraint(equalToConstant: 77),
+        ])
+        
+        
+        
     }
     
+    private func setIntroText(_ name: String?) {
+        if let name = name {
+            let message = "님,\n오늘 연습할 곡은 무엇인가요?"
+            
+            // 커스텀 폰트 로드
+            let boldFont = UIFont(name: "SUIT-SemiBold", size: 23) ?? UIFont.systemFont(ofSize: 23, weight: .semibold)
+            let regularFont = UIFont(name: "SUIT-Regular", size: 23) ?? UIFont.systemFont(ofSize: 23)
+            
+            // 전체 텍스트를 NSMutableAttributedString으로 생성
+            let attributedText = NSMutableAttributedString(string: name, attributes: [
+                .font: boldFont // 이름 부분을 굵게 설정
+            ])
+            
+            // 나머지 텍스트 추가
+            let normalText = NSAttributedString(string: message, attributes: [
+                .font: regularFont // 나머지 부분은 기본 폰트 설정
+            ])
+            
+            // 나머지 텍스트를 추가
+            attributedText.append(normalText)
+            
+            // UILabel에 attributed text 설정
+            introLabel.attributedText = attributedText
+        }
+    }
     
+    private func configureButton(_ userRole: String?) {
+        print(userRole ?? "userRole이 없는데요?")
+        
+        let icon = userRole == "COACH" ? UIImage(systemName: "person.3.fill") : UIImage(systemName: "pencil")
+        if let icon = icon {
+            manageRequestButton.setIcon(icon)
+        }
+        
+        let title = userRole == "COACH" ? "학생 관리" : "수업 관리"
+        manageRequestButton.setTitleLabel(title)
+        
+        let action = userRole == "COACH" ? #selector(homeViewController?.didTapManageStudentBtn) : #selector(homeViewController?.didTapManageLessonBtn)
+        manageRequestButton.addTarget(homeViewController, action: action, for: .touchUpInside)
+    }
     
 }


### PR DESCRIPTION
재로그인 시 새롭게 로그인한 유저의 정보를 받아오는 데에 성공했지만 UI 요소에 바로 반영되지 않는 에러 있었음.
- updateUI 메서드 View 측으로 옮겨서 유저모델 넘겨 이용함으로서 해결 코치와 학생 역할에 따라 홈에서의 버튼 다르게 구현. 당장은 학생관리 vs 수업관리로 나뉘어짐. 학생관리 탭 시 페이지 이동하도록 구현