### PR TITLE
닉네임 변경 내 중복 검사 로직 및 UI 구현, 좋아요한 챌린지 포스트 관련 기능 일부 구현

### DIFF
--- a/VoQal_iOS.xcodeproj/project.pbxproj
+++ b/VoQal_iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		956C1C072C4E18FB00ECAADA /* EditReservationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C1C062C4E18FB00ECAADA /* EditReservationView.swift */; };
 		956C1C092C4E192B00ECAADA /* EditReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C1C082C4E192B00ECAADA /* EditReservationViewController.swift */; };
 		956C1C0B2C4FAD5500ECAADA /* YoutubeUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C1C0A2C4FAD5500ECAADA /* YoutubeUtility.swift */; };
+		956CAFB82C7E11AE00C3A46A /* MyLikePostChallengePostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956CAFB72C7E11AE00C3A46A /* MyLikePostChallengePostManager.swift */; };
 		956EC07F2C56071200983AE6 /* TextFieldWithBottomBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956EC07E2C56071200983AE6 /* TextFieldWithBottomBorder.swift */; };
 		956EC0812C56257D00983AE6 /* SetLessonSongManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956EC0802C56257D00983AE6 /* SetLessonSongManager.swift */; };
 		956EC0832C5625CB00983AE6 /* SetLessonSongModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956EC0822C5625CB00983AE6 /* SetLessonSongModel.swift */; };
@@ -79,6 +80,12 @@
 		956FFD9E2C51240D00DD7995 /* WriteLessonNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFD9D2C51240D00DD7995 /* WriteLessonNoteViewController.swift */; };
 		956FFDA02C512B7600DD7995 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFD9F2C512B7600DD7995 /* CustomTextField.swift */; };
 		956FFDA22C51401A00DD7995 /* CustomTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFDA12C51401A00DD7995 /* CustomTextView.swift */; };
+		956FFED12C8347C500F92604 /* MyLikePostData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFED02C8347C500F92604 /* MyLikePostData.swift */; };
+		956FFED32C8347D000F92604 /* MyLikePostModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFED22C8347D000F92604 /* MyLikePostModel.swift */; };
+		956FFED52C834B3900F92604 /* MyLikePostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFED42C834B3900F92604 /* MyLikePostCollectionViewCell.swift */; };
+		956FFED72C83622100F92604 /* EditNicknameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFED62C83622100F92604 /* EditNicknameManager.swift */; };
+		956FFED92C83628100F92604 /* EditNicknameData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFED82C83628100F92604 /* EditNicknameData.swift */; };
+		956FFEDB2C83628800F92604 /* EditNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956FFEDA2C83628800F92604 /* EditNicknameModel.swift */; };
 		95708F522C608B630034F6FD /* StudentRecordFileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95708F512C608B630034F6FD /* StudentRecordFileTableViewCell.swift */; };
 		95708F562C608BB60034F6FD /* StudentLessonNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95708F552C608BB60034F6FD /* StudentLessonNoteTableViewCell.swift */; };
 		9570F0962C4CFBD00004AA67 /* MyReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9570F0952C4CFBD00004AA67 /* MyReservationViewController.swift */; };
@@ -126,6 +133,13 @@
 		9581D8BC2C6243F7009BE1B2 /* LessonNoteDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9581D8BB2C6243F7009BE1B2 /* LessonNoteDetailData.swift */; };
 		9581D8BE2C624402009BE1B2 /* LessonNoteDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9581D8BD2C624402009BE1B2 /* LessonNoteDetailModel.swift */; };
 		9582059B2C60F2E700C1A280 /* PrivateUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9582059A2C60F2E700C1A280 /* PrivateUrl.swift */; };
+		9582937C2C7B3C390041CC14 /* EditNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9582937B2C7B3C390041CC14 /* EditNicknameViewController.swift */; };
+		9582937E2C7B3C4A0041CC14 /* EditNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9582937D2C7B3C4A0041CC14 /* EditNicknameView.swift */; };
+		958293802C7B3E690041CC14 /* ChangeCoachView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9582937F2C7B3E690041CC14 /* ChangeCoachView.swift */; };
+		958293822C7B3E9C0041CC14 /* ChangeCoachViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958293812C7B3E9C0041CC14 /* ChangeCoachViewController.swift */; };
+		958293842C7B41680041CC14 /* ChangeCoachManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958293832C7B41680041CC14 /* ChangeCoachManager.swift */; };
+		958293862C7B41E00041CC14 /* ChangeCoachData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958293852C7B41E00041CC14 /* ChangeCoachData.swift */; };
+		958293882C7B41EA0041CC14 /* ChangeCoachModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958293872C7B41EA0041CC14 /* ChangeCoachModel.swift */; };
 		9584A22C2C6E087200E0BC99 /* ChallengeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9584A22B2C6E087200E0BC99 /* ChallengeData.swift */; };
 		9584A22E2C6E087A00E0BC99 /* ChallengeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9584A22D2C6E087A00E0BC99 /* ChallengeModel.swift */; };
 		9584A2302C6E095900E0BC99 /* MyChallengePostData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9584A22F2C6E095900E0BC99 /* MyChallengePostData.swift */; };
@@ -255,6 +269,7 @@
 		956C1C062C4E18FB00ECAADA /* EditReservationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditReservationView.swift; sourceTree = "<group>"; };
 		956C1C082C4E192B00ECAADA /* EditReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditReservationViewController.swift; sourceTree = "<group>"; };
 		956C1C0A2C4FAD5500ECAADA /* YoutubeUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeUtility.swift; sourceTree = "<group>"; };
+		956CAFB72C7E11AE00C3A46A /* MyLikePostChallengePostManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLikePostChallengePostManager.swift; sourceTree = "<group>"; };
 		956EC07E2C56071200983AE6 /* TextFieldWithBottomBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldWithBottomBorder.swift; sourceTree = "<group>"; };
 		956EC0802C56257D00983AE6 /* SetLessonSongManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLessonSongManager.swift; sourceTree = "<group>"; };
 		956EC0822C5625CB00983AE6 /* SetLessonSongModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLessonSongModel.swift; sourceTree = "<group>"; };
@@ -289,6 +304,12 @@
 		956FFD9D2C51240D00DD7995 /* WriteLessonNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteLessonNoteViewController.swift; sourceTree = "<group>"; };
 		956FFD9F2C512B7600DD7995 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		956FFDA12C51401A00DD7995 /* CustomTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextView.swift; sourceTree = "<group>"; };
+		956FFED02C8347C500F92604 /* MyLikePostData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLikePostData.swift; sourceTree = "<group>"; };
+		956FFED22C8347D000F92604 /* MyLikePostModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLikePostModel.swift; sourceTree = "<group>"; };
+		956FFED42C834B3900F92604 /* MyLikePostCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLikePostCollectionViewCell.swift; sourceTree = "<group>"; };
+		956FFED62C83622100F92604 /* EditNicknameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNicknameManager.swift; sourceTree = "<group>"; };
+		956FFED82C83628100F92604 /* EditNicknameData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNicknameData.swift; sourceTree = "<group>"; };
+		956FFEDA2C83628800F92604 /* EditNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNicknameModel.swift; sourceTree = "<group>"; };
 		95708F512C608B630034F6FD /* StudentRecordFileTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentRecordFileTableViewCell.swift; sourceTree = "<group>"; };
 		95708F552C608BB60034F6FD /* StudentLessonNoteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentLessonNoteTableViewCell.swift; sourceTree = "<group>"; };
 		9570F0952C4CFBD00004AA67 /* MyReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReservationViewController.swift; sourceTree = "<group>"; };
@@ -334,6 +355,13 @@
 		9581D8BB2C6243F7009BE1B2 /* LessonNoteDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonNoteDetailData.swift; sourceTree = "<group>"; };
 		9581D8BD2C624402009BE1B2 /* LessonNoteDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonNoteDetailModel.swift; sourceTree = "<group>"; };
 		9582059A2C60F2E700C1A280 /* PrivateUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateUrl.swift; sourceTree = "<group>"; };
+		9582937B2C7B3C390041CC14 /* EditNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNicknameViewController.swift; sourceTree = "<group>"; };
+		9582937D2C7B3C4A0041CC14 /* EditNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNicknameView.swift; sourceTree = "<group>"; };
+		9582937F2C7B3E690041CC14 /* ChangeCoachView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCoachView.swift; sourceTree = "<group>"; };
+		958293812C7B3E9C0041CC14 /* ChangeCoachViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCoachViewController.swift; sourceTree = "<group>"; };
+		958293832C7B41680041CC14 /* ChangeCoachManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCoachManager.swift; sourceTree = "<group>"; };
+		958293852C7B41E00041CC14 /* ChangeCoachData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCoachData.swift; sourceTree = "<group>"; };
+		958293872C7B41EA0041CC14 /* ChangeCoachModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCoachModel.swift; sourceTree = "<group>"; };
 		9584A22B2C6E087200E0BC99 /* ChallengeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeData.swift; sourceTree = "<group>"; };
 		9584A22D2C6E087A00E0BC99 /* ChallengeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeModel.swift; sourceTree = "<group>"; };
 		9584A22F2C6E095900E0BC99 /* MyChallengePostData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyChallengePostData.swift; sourceTree = "<group>"; };
@@ -506,6 +534,8 @@
 			children = (
 				9541D3812BD2AFEE00B36977 /* MyPageViewController.swift */,
 				95E9C8592C74CD0D00FE2042 /* CancelAccountViewController.swift */,
+				9582937B2C7B3C390041CC14 /* EditNicknameViewController.swift */,
+				958293812C7B3E9C0041CC14 /* ChangeCoachViewController.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -798,6 +828,7 @@
 				957595982C6D137500DA65D1 /* PostChallengeManager.swift */,
 				9584A2352C6E0A9C00E0BC99 /* ChallengeManager.swift */,
 				9584A2372C6E0AAD00E0BC99 /* MyChallengePostManager.swift */,
+				956CAFB72C7E11AE00C3A46A /* MyLikePostChallengePostManager.swift */,
 			);
 			path = Challenge;
 			sourceTree = "<group>";
@@ -811,6 +842,8 @@
 				9584A22D2C6E087A00E0BC99 /* ChallengeModel.swift */,
 				9584A22F2C6E095900E0BC99 /* MyChallengePostData.swift */,
 				9584A2312C6E096100E0BC99 /* MyChallengePostModel.swift */,
+				956FFED02C8347C500F92604 /* MyLikePostData.swift */,
+				956FFED22C8347D000F92604 /* MyLikePostModel.swift */,
 			);
 			path = Challenge;
 			sourceTree = "<group>";
@@ -830,6 +863,8 @@
 			isa = PBXGroup;
 			children = (
 				957E6F8B2C78BF5300093C9E /* CancelAccountManager.swift */,
+				958293832C7B41680041CC14 /* ChangeCoachManager.swift */,
+				956FFED62C83622100F92604 /* EditNicknameManager.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -839,6 +874,10 @@
 			children = (
 				957E6F8E2C78BF9D00093C9E /* CancelAccountData.swift */,
 				957E6F902C78BFA600093C9E /* CancelAccountModel.swift */,
+				958293852C7B41E00041CC14 /* ChangeCoachData.swift */,
+				958293872C7B41EA0041CC14 /* ChangeCoachModel.swift */,
+				956FFED82C83628100F92604 /* EditNicknameData.swift */,
+				956FFEDA2C83628800F92604 /* EditNicknameModel.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -994,6 +1033,8 @@
 			children = (
 				95A0D4412C43AD8E002A768B /* MyPageView.swift */,
 				95E9C85B2C74CD3100FE2042 /* CancelAccountView.swift */,
+				9582937D2C7B3C4A0041CC14 /* EditNicknameView.swift */,
+				9582937F2C7B3E690041CC14 /* ChangeCoachView.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -1008,6 +1049,7 @@
 				955B4ACB2C67AE9600AC2E20 /* ChallengeCollectionViewCell.swift */,
 				95E9C8572C74B8F500FE2042 /* MyPageMenuTableViewCell.swift */,
 				957E6F882C78AA0700093C9E /* MyChallengePostCellTableViewCell.swift */,
+				956FFED42C834B3900F92604 /* MyLikePostCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1344,6 +1386,7 @@
 				957E3E122C344D1700936617 /* NicknameVerifyData.swift in Sources */,
 				956EDA462C6495A50071EBEC /* RecordFileDetailView.swift in Sources */,
 				957E6F8F2C78BF9D00093C9E /* CancelAccountData.swift in Sources */,
+				956CAFB82C7E11AE00C3A46A /* MyLikePostChallengePostManager.swift in Sources */,
 				956FFD9C2C5123F300DD7995 /* WriteLessonNoteView.swift in Sources */,
 				955B55A42C5297A5004C097E /* UploadRecordViewController.swift in Sources */,
 				956EC07F2C56071200983AE6 /* TextFieldWithBottomBorder.swift in Sources */,
@@ -1365,9 +1408,11 @@
 				9563257E2C6A36A400C801A4 /* MyChallengePostViewController.swift in Sources */,
 				959D94362C2EE0D40014F086 /* EmailResultView.swift in Sources */,
 				957E6F892C78AA0700093C9E /* MyChallengePostCellTableViewCell.swift in Sources */,
+				958293822C7B3E9C0041CC14 /* ChangeCoachViewController.swift in Sources */,
 				9581D8BC2C6243F7009BE1B2 /* LessonNoteDetailData.swift in Sources */,
 				9509C3BD2C3D409D00FE211E /* CoachSelectionViewController.swift in Sources */,
 				95786E8E2C40233800F77146 /* LoginData.swift in Sources */,
+				956FFED12C8347C500F92604 /* MyLikePostData.swift in Sources */,
 				9575959C2C6D157300DA65D1 /* PostChallengeData.swift in Sources */,
 				959D94382C2EE7C80014F086 /* EmailResultViewController.swift in Sources */,
 				956EC08F2C5796FC00983AE6 /* UploadRecordFileManager.swift in Sources */,
@@ -1375,6 +1420,7 @@
 				9584A2362C6E0A9C00E0BC99 /* ChallengeManager.swift in Sources */,
 				955B4ACC2C67AE9600AC2E20 /* ChallengeCollectionViewCell.swift in Sources */,
 				95B5C6712BCABE490067432A /* ViewController.swift in Sources */,
+				958293802C7B3E690041CC14 /* ChangeCoachView.swift in Sources */,
 				956EC0832C5625CB00983AE6 /* SetLessonSongModel.swift in Sources */,
 				9541D3732BD2AEB100B36977 /* MainTabBarController.swift in Sources */,
 				956EC0852C5625DA00983AE6 /* SetLessonSongData.swift in Sources */,
@@ -1384,6 +1430,7 @@
 				95708F562C608BB60034F6FD /* StudentLessonNoteTableViewCell.swift in Sources */,
 				9570F09C2C4CFF590004AA67 /* MyReservationManager.swift in Sources */,
 				9581B0E82C5CD524008D7701 /* StudentRecordFileModel.swift in Sources */,
+				9582937C2C7B3C390041CC14 /* EditNicknameViewController.swift in Sources */,
 				95A0D43F2C43997B002A768B /* UserManager.swift in Sources */,
 				958FE7CC2C42C33000F2954D /* HomeData.swift in Sources */,
 				956C1C0B2C4FAD5500ECAADA /* YoutubeUtility.swift in Sources */,
@@ -1399,6 +1446,7 @@
 				9581B0CE2C5CB75C008D7701 /* LessonTabViewController.swift in Sources */,
 				9542B6422BCD6C470060E1BB /* RegistrationViewController.swift in Sources */,
 				956325822C6A381500C801A4 /* PostChallengeViewController.swift in Sources */,
+				958293842C7B41680041CC14 /* ChangeCoachManager.swift in Sources */,
 				959D943F2C2EF75E0014F086 /* EmailFinderData.swift in Sources */,
 				958D42452C37DDEC00088EA3 /* ValidationUtility.swift in Sources */,
 				9575959E2C6D157A00DA65D1 /* PostChallengeModel.swift in Sources */,
@@ -1429,9 +1477,11 @@
 				9587DDFB2C46C4670039B6D0 /* ManageStudentView.swift in Sources */,
 				956F3C262C47C9E400F63F33 /* RequestListViewController.swift in Sources */,
 				959D943D2C2EF7520014F086 /* EmailFinderModel.swift in Sources */,
+				958293862C7B41E00041CC14 /* ChangeCoachData.swift in Sources */,
 				9581B0E02C5CD435008D7701 /* StudentRecordFileManager.swift in Sources */,
 				9584A22C2C6E087200E0BC99 /* ChallengeData.swift in Sources */,
 				956FFD9A2C5123DA00DD7995 /* WriteLessonNoteManager.swift in Sources */,
+				956FFED92C83628100F92604 /* EditNicknameData.swift in Sources */,
 				9570F0982C4CFBF80004AA67 /* MyReservationView.swift in Sources */,
 				9541D3332BD29CCA00B36977 /* HomeViewController.swift in Sources */,
 				957E3E192C344E0100936617 /* PasswordResetModel.swift in Sources */,
@@ -1449,7 +1499,9 @@
 				955B55A62C5297BE004C097E /* UploadRecordView.swift in Sources */,
 				956F3C322C47DC3A00F63F33 /* RequestListModel.swift in Sources */,
 				956F3C362C47E1AD00F63F33 /* RequestListTableViewCell.swift in Sources */,
+				958293882C7B41EA0041CC14 /* ChangeCoachModel.swift in Sources */,
 				9581B0E22C5CD506008D7701 /* StudentLessonNoteData.swift in Sources */,
+				956FFED32C8347D000F92604 /* MyLikePostModel.swift in Sources */,
 				9584A2322C6E096100E0BC99 /* MyChallengePostModel.swift in Sources */,
 				957595992C6D137500DA65D1 /* PostChallengeManager.swift in Sources */,
 				95715A9F2C4673130010D4B7 /* UserModel.swift in Sources */,
@@ -1460,18 +1512,22 @@
 				959B57562C41268D009428D7 /* AuthInterceptor.swift in Sources */,
 				9581D8BA2C62418A009BE1B2 /* LessonNoteDetailViewController.swift in Sources */,
 				9581B0D02C5CBF74008D7701 /* LessonNoteTableViewController.swift in Sources */,
+				956FFED52C834B3900F92604 /* MyLikePostCollectionViewCell.swift in Sources */,
 				956FFDA22C51401A00DD7995 /* CustomTextView.swift in Sources */,
 				956EC0932C5912EA00983AE6 /* SNSWebView.swift in Sources */,
 				959D94292C2C7A650014F086 /* RegistrationModel.swift in Sources */,
+				956FFED72C83622100F92604 /* EditNicknameManager.swift in Sources */,
 				9584A22E2C6E087A00E0BC99 /* ChallengeModel.swift in Sources */,
 				957E6F8C2C78BF5300093C9E /* CancelAccountManager.swift in Sources */,
 				9587DDF32C46BA880039B6D0 /* CustomButtonView.swift in Sources */,
 				959D94212C2AEF100014F086 /* RegistrationManager.swift in Sources */,
 				956C1C092C4E192B00ECAADA /* EditReservationViewController.swift in Sources */,
+				9582937E2C7B3C4A0041CC14 /* EditNicknameView.swift in Sources */,
 				956F3C3E2C49034200F63F33 /* ReservationData.swift in Sources */,
 				957E3E102C344D0600936617 /* EmailVerifyData.swift in Sources */,
 				95B6616B2C3D309F0091F241 /* RoleSelectionButton.swift in Sources */,
 				95A0D4442C43ADE9002A768B /* BaseView.swift in Sources */,
+				956FFEDB2C83628800F92604 /* EditNicknameModel.swift in Sources */,
 				957E3E152C344DD800936617 /* EmailVerifyModel.swift in Sources */,
 				9570F09A2C4CFD070004AA67 /* MyReservationTableViewCell.swift in Sources */,
 				959D94312C2D66B80014F086 /* EmailFinderViewController.swift in Sources */,
@@ -1674,6 +1730,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1706,6 +1763,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/VoQal_iOS/Controllers/Challenge/MyLikePostChallengeViewController.swift
+++ b/VoQal_iOS/Controllers/Challenge/MyLikePostChallengeViewController.swift
@@ -6,10 +6,14 @@
 //
 
 import UIKit
+import AVFoundation
 
 class MyLikePostChallengeViewController: BaseViewController {
 
     private let myLikePostChallengeView = MyLikePostChallengeView()
+    private let myLikeChallengePostManager = MyLikeChallengePostManager()
+    private let challengeManager = ChallengeManager()
+    private var myLikePosts: [MyLikePost] = []
     
     override func loadView() {
         view = myLikePostChallengeView
@@ -21,6 +25,190 @@ class MyLikePostChallengeViewController: BaseViewController {
         // Do any additional setup after loading the view.
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        playPlayer()
+        setIsHiddenCoverImageView(true)
+    }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        temporarilyStopPlayer()
+    }
+    
+    private func fetchData() {
+        
+        myLikeChallengePostManager.fetchMyLikePost { [weak self] model in
+            guard let self = self, let model = model else { print("myLikeChallengePostManager - fetchMyLikePost model is nil"); return }
+            
+            if model.status == 200 {
+                self.myLikePosts = model.data
+            }
+        }
+        
+    }
+    
+//    @objc private func didTapLikeButton(_ sender: UIButton) {
+//        let post = myLikePosts[sender.tag]
+//        let postId = Int64(post.challengeId)
+//        var liked = post.liked
+//        
+//        guard let cell = sender.superview?.superview as? ChallengeCollectionViewCell else {
+//            print("셀을 찾을 수 없습니다.")
+//            return
+//        }
+//        
+//        if liked == false {
+//            challengeManager.likeChallengePost(postId) { model in
+//                guard let model = model else { print("challengeViewController - likeChallengePost model 바인딩 실패"); return }
+//                if model.status == 200 {
+//                    // 좋아요 성공 처리
+//                    DispatchQueue.main.async {
+//                        cell.updateLikeBtn(true)
+//                        self.myLikePosts[sender.tag].liked = true // 메모리 상에 liked를 임시로 true 설정
+//                    }
+//                }
+//                else {
+//                    print("model.status가 200이 아님 (didTapLikeButton)")
+//                }
+//            }
+//        } else {
+//            challengeManager.unlikeChallengePost(postId) { model in
+//                guard let model = model else { print("challengeViewController - unlikeChallengePost model 바인딩 실패"); return }
+//                if model.status == 200 {
+//                    // 좋아요 취소 성공 처리
+//                    DispatchQueue.main.async {
+//                        cell.updateLikeBtn(false)
+//                        self.myLikePosts[sender.tag].liked = false
+//                        
+//                    }
+//                }
+//                else {
+//                    print("model.status가 200이 아님 (didTapLikeButton)")
+//                }
+//            }
+//        }
+//    }
+    
+    private func stopAllPlayers() {
+        for cell in myLikePostChallengeView.collectionView.visibleCells {
+            if let challengeCell = cell as? MyLikePostCollectionViewCell {
+                challengeCell.player?.pause()
+                challengeCell.player = nil
+            }
+        }
+    }
+    
+    private func temporarilyStopPlayer() {
+        for cell in myLikePostChallengeView.collectionView.visibleCells {
+            if let challengeCell = cell as? MyLikePostCollectionViewCell {
+                challengeCell.player?.pause()
+            }
+        }
+    }
+    
+    private func playPlayer() {
+        for cell in myLikePostChallengeView.collectionView.visibleCells {
+            if let challengeCell = cell as? MyLikePostCollectionViewCell {
+                challengeCell.player?.play()
+            }
+        }
+    }
+    
+    private func playCurrentCell(at indexPath: IndexPath) {
+        guard let cell = myLikePostChallengeView.collectionView.cellForItem(at: indexPath) as? MyLikePostCollectionViewCell else {
+            print("playCurrentCell - cell 바인딩 실패")
+            return
+        }
+        
+        if let player = cell.player {
+            player.play()
+        }
+        else {
+            print("player 바인딩 실패");
+        }
+    }
+    
+    private func setIsHiddenCoverImageView(_ isHidden: Bool) {
+        for cell in myLikePostChallengeView.collectionView.visibleCells {
+            if let challengeCell = cell as? MyLikePostCollectionViewCell {
+                challengeCell.coverImageView.isHidden = isHidden
+            }
+        }
+    }
 
+}
+
+extension MyLikePostChallengeViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return myLikePosts.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyLikePostCollectionViewCell.identifier, for: indexPath) as? MyLikePostCollectionViewCell else {
+            print("ChallengeCollectionViewCell dequeue실패.")
+            return UICollectionViewCell()
+        }
+        
+        let post = myLikePosts[indexPath.row]
+        let songTitle = post.songTitle
+        let singer = post.singer
+//        let nickname = post.nickName
+        
+//        cell.configure(songTitle, singer, nickname)
+        
+        challengeManager.downloadThumbnailImage("\(PrivateUrl.shared.getS3UrlHead())\(post.thumbnailUrl)") { [weak cell, indexPath] image in
+            guard let cell = cell, collectionView.indexPath(for: cell) == indexPath else {
+                return
+            }
+            DispatchQueue.main.async {
+                cell.updateThumbnail(image)
+            }
+        }
+        
+        // 음원 플레이어 설정
+        if let url = URL(string: "\(PrivateUrl.shared.getS3UrlHead())\(post.challengeRecordUrl)") {
+            let player = AVPlayer(url: url)
+            cell.updatePlayer(player)
+        }
+        
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        if let cell = cell as? MyLikePostCollectionViewCell {
+            cell.togglePlayPause()
+        }
+        
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        if let cell = cell as? MyLikePostCollectionViewCell {
+            cell.togglePlayPause() // 셀이 사라지면 자동으로 일시정지
+        }
+    }
+}
+
+
+
+extension MyLikePostChallengeViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = collectionView.bounds.width
+        let height = collectionView.bounds.height
+        
+        return CGSize(width: width, height: height)
+    }
+}
+
+extension MyLikePostChallengeViewController: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        if viewController != self {
+            stopAllPlayers()
+        }
+        return true
+    }
 }

--- a/VoQal_iOS/Controllers/MyPage/ChangeCoachViewController.swift
+++ b/VoQal_iOS/Controllers/MyPage/ChangeCoachViewController.swift
@@ -1,0 +1,101 @@
+//
+//  ChangeCoachViewController.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import UIKit
+
+class ChangeCoachViewController: BaseViewController {
+    
+    private let changeCoachView = ChangeCoachView()
+    private let changeCoachManager = ChangeCoachManager()
+    private var selectedIndex: Int? = nil
+    
+    private var coaches: [Coach] = []
+    
+    override func loadView() {
+        view = changeCoachView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        changeCoachView.coachTableView.dataSource = self
+        changeCoachView.coachTableView.delegate = self
+        changeCoachView.coachTableView.register(CoachSelectionTableViewCell.self, forCellReuseIdentifier: CoachSelectionTableViewCell.identifier)
+        
+        changeCoachManager.getCoachList { model in
+            guard let model = model else { print("changeCoachViewController - getCoachList model 바인딩 실패"); return }
+            
+            if model.status == 200 {
+                guard let coaches = model.data else { print("model.data가 nil입니다."); return }
+                
+                self.coaches = coaches
+                self.changeCoachView.coachTableView.reloadData()
+            }
+        }
+    }
+    
+    override func setAddTarget() {
+        changeCoachView.changeCoachButton.addTarget(self, action: #selector(didTapChangeCoachButton), for: .touchUpInside)
+    }
+    
+    
+    
+    @objc private func didTapChangeCoachButton() {
+        guard let selectedIndex = self.selectedIndex else { print("selectedIndex is nil - 담당 코치 변경"); return }
+        print("새 코치 id: \(coaches[selectedIndex].id)")
+        changeCoachManager.changeCoach(coachId: coaches[selectedIndex].id) { model in
+            guard let model = model else { print("changeCoach model 바인딩 실패"); return }
+            
+            if model.status == 200 {
+                let alert = UIAlertController(title: "담당 코치 신청 완료!", message: "새 담당코치님의 승인을 기다리는 중입니다. 승인 후에 담당 코치 변경이 반영되니 기다려주세요!", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+                    self.navigationController?.popViewController(animated: true)
+                }))
+                alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+                self.present(alert, animated: false)
+            }
+            else {
+                print("changeCoach - model.status is not 200")
+            }
+        }
+    }
+    
+}
+
+extension ChangeCoachViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return coaches.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: CoachSelectionTableViewCell.identifier, for: indexPath) as? CoachSelectionTableViewCell else {
+            return UITableViewCell()
+        }
+        let coachName = coaches[indexPath.row]
+        cell.configure(with: coachName.name)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let cell = tableView.cellForRow(at: indexPath) as? CoachSelectionTableViewCell {
+            cell.setSelected(true, animated: true)
+            selectedIndex = indexPath.row
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        if let cell = tableView.cellForRow(at: indexPath) as? CoachSelectionTableViewCell {
+            cell.setSelected(false, animated: true)
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100 // 셀 높이를 늘려서 간격을 확보
+    }
+    
+}

--- a/VoQal_iOS/Controllers/MyPage/EditNicknameViewController.swift
+++ b/VoQal_iOS/Controllers/MyPage/EditNicknameViewController.swift
@@ -1,0 +1,84 @@
+//
+//  EditProfileViewController.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import UIKit
+
+class EditNicknameViewController: BaseViewController {
+
+    internal var isNicknameVerified = false
+    
+    private let editNicknameView = EditNicknameView()
+    private let editNicknameManager = EditNicknameManager()
+    
+    
+    override func loadView() {
+        view = editNicknameView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        editNicknameView.editNicknameVC = self
+        view.backgroundColor = .clear
+    }
+    
+    override func setAddTarget() {
+        editNicknameView.nicknameVerifyButton.addTarget(self, action: #selector(didTapNicknameVerifyBtn), for: .touchUpInside)
+    }
+    
+    @objc private func didTapNicknameVerifyBtn() {
+        
+        if editNicknameView.nicknameVerifyButton.titleLabel!.text == "중복확인" {
+            guard let nickname = editNicknameView.nicknameField.text else {
+                print("nickname Field로부터 nickname값을 받아오는 데에 실패했습니다.")
+                return
+            }
+            
+            if editNicknameView.isNicknameAPICallInProgress || editNicknameView.isNicknameEditingInProgress {
+                return
+            }
+            
+            if !ValidationUtility.isValidNickname(nickname) {
+                return
+            }
+            
+            editNicknameView.isNicknameAPICallInProgress = true
+            editNicknameView.nicknameVerifyButton.isEnabled = false
+            
+            editNicknameManager.nicknameDuplicateCheck(nickname) { model in
+                self.editNicknameView.isNicknameAPICallInProgress = false
+                
+                if model?.status == 200 {
+                    self.isNicknameVerified = true
+                    self.editNicknameView.originalNickname = nickname // originNickname 업데이트
+                    self.editNicknameView.updateNicknameVerificationButton(isVerified: true)
+                    self.editNicknameView.updateNicknameVerifyLabel(true)
+                } else if model?.status == 400 {
+                    self.isNicknameVerified = false
+                    self.editNicknameView.updateNicknameVerificationButton(isVerified: false)
+                    self.editNicknameView.updateNicknameVerifyLabel(false)
+                }
+            }
+            
+            
+            if !self.editNicknameView.isNicknameEditingInProgress {
+                self.editNicknameView.nicknameVerifyButton.isEnabled = true
+            }
+            
+        }
+        else if editNicknameView.nicknameVerifyButton.titleLabel!.text == "수정" {
+            self.editNicknameView.updateNicknameVerificationButton(isVerified: false)
+            self.editNicknameView.clearNicknameVerifyLabel()
+            self.isNicknameVerified = false
+        }
+    }
+
+//    @objc private func didTapCompleteButton() {
+//        editNicknameManager.editNickname(<#T##id: Int64##Int64#>, completion: <#T##(EditNicknameModel?) -> Void#>)
+//    }
+    
+}

--- a/VoQal_iOS/Controllers/MyPage/MyPageViewController.swift
+++ b/VoQal_iOS/Controllers/MyPage/MyPageViewController.swift
@@ -39,6 +39,8 @@ class MyPageViewController: BaseViewController {
     
     override func setAddTarget() {
         super.setAddTarget()
+        
+        myPageView.changeNicknameButton.addTarget(self, action: #selector(didTapChangeNicknameButton), for: .touchUpInside)
     }
     
     private func setUserInformation() {
@@ -98,6 +100,15 @@ class MyPageViewController: BaseViewController {
             self.present(sendMailErrorAlert, animated: true, completion: nil)
         }
         
+    }
+    
+    @objc private func didTapChangeNicknameButton() {
+        print("닉네임 변경 Tap!")
+        
+        let vc = EditNicknameViewController()
+        vc.modalPresentationStyle = .overFullScreen
+        
+        present(vc, animated: true)
     }
     
     private func didTapCancelAccountButton() {

--- a/VoQal_iOS/Controllers/Onboarding/RegistrationViewController.swift
+++ b/VoQal_iOS/Controllers/Onboarding/RegistrationViewController.swift
@@ -46,7 +46,6 @@ class RegistrationViewController: UIViewController {
     }
     
     @objc private func didTapEmailVerifyBtn() {
-        
         if registrationView.emailVerifyButton.titleLabel!.text == "중복확인" {
             guard let email = registrationView.emailField.text else {
                 print("email Field로부터 email값을 받아오는 데에 실패했습니다.")
@@ -63,11 +62,9 @@ class RegistrationViewController: UIViewController {
             
             registrationView.isEmailAPICallInProgress = true
             registrationView.emailVerifyButton.isEnabled = false
-            registrationView.emailDispatchGroup.enter()
             
             registrationManager.emailDuplicateCheck(email) { model in
                 self.registrationView.isEmailAPICallInProgress = false
-                self.registrationView.emailDispatchGroup.leave()
                 
                 if model?.status == 200 {
                     self.isEmailVerified = true
@@ -77,19 +74,15 @@ class RegistrationViewController: UIViewController {
                     self.isEmailVerified = false
                     self.registrationView.updateEmailVerificationButton(isVerified: false)
                 }
-            }
-            
-            registrationView.emailDispatchGroup.notify(queue: .main) {
+                
                 if !self.registrationView.isEmailEditingInProgress {
                     self.registrationView.emailVerifyButton.isEnabled = true
                 }
             }
-        }
-        else if registrationView.emailVerifyButton.titleLabel!.text == "수정" {
+        } else if registrationView.emailVerifyButton.titleLabel!.text == "수정" {
             self.registrationView.updateEmailVerificationButton(isVerified: false)
             self.isEmailVerified = false
         }
-        
     }
     
     // 닉네임 중복 확인 버튼 클릭 처리
@@ -111,11 +104,9 @@ class RegistrationViewController: UIViewController {
             
             registrationView.isNicknameAPICallInProgress = true
             registrationView.nicknameVerifyButton.isEnabled = false
-            registrationView.nicknameDispatchGroup.enter()
             
             registrationManager.nicknameDuplicateCheck(nickname) { model in
                 self.registrationView.isNicknameAPICallInProgress = false
-                self.registrationView.nicknameDispatchGroup.leave()
                 
                 if model?.status == 200 {
                     self.isNicknameVerified = true
@@ -127,11 +118,11 @@ class RegistrationViewController: UIViewController {
                 }
             }
             
-            registrationView.nicknameDispatchGroup.notify(queue: .main) {
-                if !self.registrationView.isNicknameEditingInProgress {
-                    self.registrationView.nicknameVerifyButton.isEnabled = true
-                }
+            
+            if !self.registrationView.isNicknameEditingInProgress {
+                self.registrationView.nicknameVerifyButton.isEnabled = true
             }
+            
         }
         else if registrationView.nicknameVerifyButton.titleLabel!.text == "수정" {
             self.registrationView.updateNicknameVerificationButton(isVerified: false)

--- a/VoQal_iOS/Models/Challenge/MyChallengePostData.swift
+++ b/VoQal_iOS/Models/Challenge/MyChallengePostData.swift
@@ -21,3 +21,12 @@ struct MyChallengePost: Codable {
     let nickName: String
     let likeCount: Int
 }
+
+struct EditChallengePostData: Codable {
+    
+}
+
+struct DeleteChallengePostData: Codable {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/Challenge/MyChallengePostModel.swift
+++ b/VoQal_iOS/Models/Challenge/MyChallengePostModel.swift
@@ -11,3 +11,12 @@ struct MyChallengePostModel {
     let status: Int
     let data: [MyChallengePost]?
 }
+
+struct EditChallengePostModel {
+    
+}
+
+struct DeleteChallengePostModel {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/Challenge/MyLikePostData.swift
+++ b/VoQal_iOS/Models/Challenge/MyLikePostData.swift
@@ -1,0 +1,21 @@
+//
+//  MyLikePostData.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/31/24.
+//
+
+import Foundation
+
+struct MyLikePostData: Codable {
+    let status: Int
+    let data: [MyLikePost]?
+}
+
+struct MyLikePost: Codable {
+    let challengeId: Int
+    let challengeRecordUrl: String
+    let thumbnailUrl: String
+    let songTitle: String
+    let singer: String
+}

--- a/VoQal_iOS/Models/Challenge/MyLikePostModel.swift
+++ b/VoQal_iOS/Models/Challenge/MyLikePostModel.swift
@@ -1,0 +1,13 @@
+//
+//  MyLikePostModel.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/31/24.
+//
+
+import Foundation
+
+struct MyLikePostModel {
+    let status: Int
+    let data: [MyLikePost]
+}

--- a/VoQal_iOS/Models/MyPage/ChangeCoachData.swift
+++ b/VoQal_iOS/Models/MyPage/ChangeCoachData.swift
@@ -1,0 +1,18 @@
+//
+//  ChangeCoachData.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import Foundation
+
+struct ChangeCoachListData: Codable {
+    let status: Int
+    let data: [Coach]?
+}
+
+struct ChangeCoachData: Codable {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/MyPage/ChangeCoachModel.swift
+++ b/VoQal_iOS/Models/MyPage/ChangeCoachModel.swift
@@ -1,0 +1,18 @@
+//
+//  ChangeCoachModel.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import Foundation
+
+struct ChangeCoachListModel {
+    let status: Int
+    let data: [Coach]?
+}
+
+struct ChangeCoachModel {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/MyPage/EditNicknameData.swift
+++ b/VoQal_iOS/Models/MyPage/EditNicknameData.swift
@@ -1,0 +1,13 @@
+//
+//  editNicknameData.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/31/24.
+//
+
+import Foundation
+
+struct EditNicknameData: Codable {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/MyPage/EditNicknameModel.swift
+++ b/VoQal_iOS/Models/MyPage/EditNicknameModel.swift
@@ -1,0 +1,13 @@
+//
+//  editNicknameModel.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/31/24.
+//
+
+import Foundation
+
+struct EditNicknameModel {
+    let message: String
+    let status: Int
+}

--- a/VoQal_iOS/Networking/Challenge/MyChallengePostManager.swift
+++ b/VoQal_iOS/Networking/Challenge/MyChallengePostManager.swift
@@ -51,4 +51,27 @@ struct MyChallengePostManager {
         }
     }
     
+    func deleteChallengePost(_ challengeId: Int64, completion: @escaping (DeleteChallengePostModel?) -> Void) {
+        let url = "https://www.voqal.today/challenge/\(challengeId)"
+        
+        AF.request(url, method: .delete, interceptor: AuthInterceptor()).responseDecodable(of: DeleteChallengePostData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let message = res.message
+                let status = res.status
+                let model = DeleteChallengePostModel(message: message, status: status)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+        
+    }
+    
+    func editChallengePost() {
+        
+    }
+    
 }

--- a/VoQal_iOS/Networking/Challenge/MyLikePostChallengePostManager.swift
+++ b/VoQal_iOS/Networking/Challenge/MyLikePostChallengePostManager.swift
@@ -1,0 +1,31 @@
+//
+//  MyLikePostChallengePostManager.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/27/24.
+//
+
+import Foundation
+import Alamofire
+
+struct MyLikeChallengePostManager {
+    
+    func fetchMyLikePost(completion: @escaping (MyLikePostModel?) -> Void) {
+        let url = "https://www.voqal.today/liked"
+        
+        AF.request(url, method: .get, interceptor: AuthInterceptor()).responseDecodable(of: MyLikePostData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let status = res.status
+                guard let data = res.data else { print("fetchMyLikePost  - data is nil"); return }
+                let model = MyLikePostModel(status: status, data: data)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+    }
+    
+}

--- a/VoQal_iOS/Networking/MyPage/ChangeCoachManager.swift
+++ b/VoQal_iOS/Networking/MyPage/ChangeCoachManager.swift
@@ -1,0 +1,55 @@
+//
+//  ChangeCoachManager.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import Foundation
+import Alamofire
+
+struct ChangeCoachParameter: Encodable {
+    let coachId: Int
+}
+
+struct ChangeCoachManager {
+    
+    func getCoachList(completion: @escaping (ChangeCoachListModel?) -> Void) {
+        let url = "https://www.voqal.today/role/coach"
+        
+        AF.request(url, method: .get, interceptor: AuthInterceptor()).responseDecodable(of: ChangeCoachListData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let status = res.status
+                let data = res.data
+                let model = ChangeCoachListModel(status: status, data: data)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+    }
+    
+    func changeCoach(coachId: Int, completion: @escaping (ChangeCoachModel?) -> Void) {
+        let url = "https://www.voqal.today/request"
+        let parameter = ChangeCoachParameter(coachId: coachId)
+        
+        AF.request(url, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default, interceptor: AuthInterceptor()).responseDecodable(of: ChangeCoachData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let message = res.message
+                let status = res.status
+                let model = ChangeCoachModel(message: message, status: status)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+        
+    }
+    
+}

--- a/VoQal_iOS/Networking/MyPage/EditNicknameManager.swift
+++ b/VoQal_iOS/Networking/MyPage/EditNicknameManager.swift
@@ -1,0 +1,53 @@
+//
+//  EditNicknameManager.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/31/24.
+//
+
+import Foundation
+import Alamofire
+
+struct EditNicknameManager {
+    
+    func nicknameDuplicateCheck(_ nickname: String, completion: @escaping (NicknameVerifyModel?) -> Void) {
+        
+        let nicknameDuplicateURL: String = "https://www.voqal.today/duplicate/nickname"
+        
+        let parameter = nicknameParameter(nickName: nickname)
+        print(nickname)
+        
+        AF.request(nicknameDuplicateURL, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default).responseDecodable(of: NicknameVerifyData.self) { (response) in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let message = res.message
+                let status = res.status
+                let model = NicknameVerifyModel(message: message, status: status)
+                completion(model)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    func editNickname(_ id: Int64, completion: @escaping (EditNicknameModel?) -> Void) {
+        let url = "https://www.voqal.today/\(id)/change-nickname"
+        
+        AF.request(url, method: .patch, interceptor: AuthInterceptor()).responseDecodable(of: EditNicknameData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let message = res.message
+                let status = res.status
+                let model = EditNicknameModel(message: message, status: status)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+        
+    }
+    
+}

--- a/VoQal_iOS/Networking/Onboarding/RegistrationManager.swift
+++ b/VoQal_iOS/Networking/Onboarding/RegistrationManager.swift
@@ -13,7 +13,7 @@ struct emailParameter: Encodable {
 }
 
 struct nicknameParameter: Encodable {
-    let nickname: String
+    let nickName: String
 }
 
 struct registerParameter: Encodable {
@@ -50,7 +50,8 @@ struct RegistrationManager {
     
     func nicknameDuplicateCheck(_ nickname: String, completion: @escaping (NicknameVerifyModel?) -> Void) {
         
-        let parameter = nicknameParameter(nickname: nickname)
+        let parameter = nicknameParameter(nickName: nickname)
+        print(nickname)
         
         AF.request(nicknameDuplicateURL, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default).responseDecodable(of: NicknameVerifyData.self) { (response) in
             switch response.result {

--- a/VoQal_iOS/Resources/ValidationUtility.swift
+++ b/VoQal_iOS/Resources/ValidationUtility.swift
@@ -24,7 +24,7 @@ class ValidationUtility {
         let forbiddenStrings = ["fuck", "shit", "bitch", "ass"]
         let specialCharacterRegex = ".*[^A-Za-z0-9가-힣].*"
         
-        return nickname.count >= 3 && nickname.count <= 15 &&
+        return nickname.count >= 2 && nickname.count <= 15 &&
                !nickname.contains(" ") &&
                !forbiddenStrings.contains { nickname.lowercased().contains($0) } &&
                nickname.range(of: specialCharacterRegex, options: .regularExpression) == nil

--- a/VoQal_iOS/Views/Cells/MyChallengePostCellTableViewCell.swift
+++ b/VoQal_iOS/Views/Cells/MyChallengePostCellTableViewCell.swift
@@ -13,6 +13,25 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
     static let identifier: String = "MyChallengePostCell"
     internal var player: AVPlayer?
     
+    private let menuButton: UIButton = {
+        let button = UIButton()
+        let configuration = UIImage.SymbolConfiguration(pointSize: 23)
+        let image = UIImage(systemName: "ellipsis", withConfiguration: configuration)
+        button.setImage(image, for: .normal)
+        button.tintColor = .white
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let bodyView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor(named: "mainBackgroundColor")
+        
+        return view
+    }()
+    
     private let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 10.0
@@ -25,7 +44,7 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
         return imageView
     }()
     
-    private let coverImageView: UIView = {
+    internal let coverImageView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.layer.cornerRadius = 10.0
@@ -61,8 +80,9 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
         let configuration = UIImage.SymbolConfiguration(pointSize: 30)
         let image = UIImage(systemName: "heart.fill", withConfiguration: configuration)
         button.setImage(image, for: .normal)
-        button.tintColor = .white
+        button.tintColor = UIColor(hexCode: "FF3B30", alpha: 1.0)
         button.translatesAutoresizingMaskIntoConstraints = false
+        
         return button
     }()
     
@@ -89,19 +109,32 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
     }
     
     private func addSubViews() {
-        contentView.addSubview(thumbnailImageView)
-        contentView.addSubview(coverImageView)
-        contentView.addSubview(songLabel)
-        contentView.addSubview(nicknameLabel)
-        contentView.addSubview(likeButton)
-        contentView.addSubview(likeCountLabel)
+        contentView.addSubview(menuButton)
+        contentView.addSubview(bodyView)
+        bodyView.addSubview(thumbnailImageView)
+        bodyView.addSubview(coverImageView)
+        bodyView.addSubview(songLabel)
+        bodyView.addSubview(nicknameLabel)
+        bodyView.addSubview(likeButton)
+        bodyView.addSubview(likeCountLabel)
     }
     
     private func setConstraints() {
         NSLayoutConstraint.activate([
-            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            
+            menuButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -5),
+            menuButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 5),
+            menuButton.heightAnchor.constraint(equalToConstant: 25),
+            menuButton.widthAnchor.constraint(equalToConstant: 25),
+            
+            bodyView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            bodyView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            bodyView.topAnchor.constraint(equalTo: menuButton.bottomAnchor, constant: 10),
+            bodyView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            
+            thumbnailImageView.leadingAnchor.constraint(equalTo: bodyView.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: bodyView.trailingAnchor),
+            thumbnailImageView.topAnchor.constraint(equalTo: bodyView.topAnchor),
             thumbnailImageView.heightAnchor.constraint(equalTo: thumbnailImageView.widthAnchor, multiplier: 4.0/3.0),
             
             coverImageView.leadingAnchor.constraint(equalTo: thumbnailImageView.leadingAnchor),
@@ -137,7 +170,7 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(togglePlayPause))
         tapGesture.cancelsTouchesInView = false
         tapGesture.delegate = self
-        contentView.addGestureRecognizer(tapGesture)
+        bodyView.addGestureRecognizer(tapGesture)
     }
     
     func configure(_ likeCount: Int, _ songTitle: String, _ singer: String, _ nickname: String) {
@@ -191,6 +224,13 @@ class MyChallengePostCollectionViewCell: UICollectionViewCell, UIGestureRecogniz
             return false
         }
         return true
+    }
+    
+    func setMenuButton(_ firstItem: UIAction, _ secondItem: UIAction) {
+        let menu = UIMenu(title: "", children: [firstItem, secondItem])
+        
+        menuButton.menu = menu
+        menuButton.showsMenuAsPrimaryAction = true
     }
     
 }

--- a/VoQal_iOS/Views/Cells/MyLikePostCollectionViewCell.swift
+++ b/VoQal_iOS/Views/Cells/MyLikePostCollectionViewCell.swift
@@ -1,16 +1,16 @@
 //
-//  ChallengeCollectionViewCell.swift
+//  MyLikePostCollectionViewCell.swift
 //  VoQal_iOS
 //
-//  Created by 송규섭 on 8/10/24.
+//  Created by 송규섭 on 8/31/24.
 //
 
 import UIKit
 import AVFoundation
 
-class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate {
-    
-    static let identifier: String = "challengeCollectionViewCell"
+class MyLikePostCollectionViewCell: UICollectionViewCell {
+
+    static let identifier: String = "myLikePostCollectionViewCell"
     internal var player: AVPlayer?
     
     private let thumbnailImageView: UIImageView = {
@@ -56,16 +56,6 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
         return label
     }()
     
-    internal let likeButton: UIButton = {
-        let button = UIButton()
-        let configuration = UIImage.SymbolConfiguration(pointSize: 30)
-        let image = UIImage(systemName: "heart", withConfiguration: configuration)
-        button.setImage(image, for: .normal)
-        button.tintColor = UIColor(hexCode: "FF3B30", alpha: 1.0)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = UIColor(named: "mainBackgroundColor")
@@ -83,7 +73,6 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
         contentView.addSubview(coverImageView)
         contentView.addSubview(songLabel)
         contentView.addSubview(nicknameLabel)
-        contentView.addSubview(likeButton)
     }
     
     private func setConstraints() {
@@ -98,19 +87,14 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
             coverImageView.topAnchor.constraint(equalTo: thumbnailImageView.topAnchor),
             coverImageView.bottomAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor),
             
-            likeButton.trailingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor),
-            likeButton.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 25),
-            likeButton.widthAnchor.constraint(equalToConstant: 40),
-            likeButton.heightAnchor.constraint(equalToConstant: 40),
-            
             songLabel.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 15),
             songLabel.leadingAnchor.constraint(equalTo: thumbnailImageView.leadingAnchor, constant: 5),
-            songLabel.trailingAnchor.constraint(lessThanOrEqualTo: likeButton.leadingAnchor, constant: -5),
+            songLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -40),
             songLabel.heightAnchor.constraint(equalToConstant: 25),
             
             nicknameLabel.leadingAnchor.constraint(equalTo: songLabel.leadingAnchor),
             nicknameLabel.topAnchor.constraint(equalTo: songLabel.bottomAnchor, constant: 10),
-            nicknameLabel.trailingAnchor.constraint(lessThanOrEqualTo: likeButton.leadingAnchor, constant: -5),
+            nicknameLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -40),
             nicknameLabel.heightAnchor.constraint(equalToConstant: 25),
             
         ])
@@ -119,14 +103,10 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
     
     private func setupGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(togglePlayPause))
-        tapGesture.cancelsTouchesInView = false
-        tapGesture.delegate = self
         contentView.addGestureRecognizer(tapGesture)
     }
     
-    func configure(_ liked: Bool, _ songTitle: String, _ singer: String, _ nickname: String) {
-        
-        updateLikeBtn(liked)
+    func configure(_ songTitle: String, _ singer: String, _ nickname: String) {
         
         self.songLabel.text = "\(songTitle) - \(singer) cover"
         self.nicknameLabel.text = nickname
@@ -143,16 +123,6 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
     func updatePlayer(_ player: AVPlayer?) {
         self.player = player
         print("player: \(player)")
-    }
-    
-    func updateLikeBtn(_ liked: Bool) {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 30)
-        
-        if liked {
-            self.likeButton.setImage(UIImage(systemName: "heart.fill", withConfiguration: configuration), for: .normal)
-        } else {
-            self.likeButton.setImage(UIImage(systemName: "heart", withConfiguration: configuration), for: .normal)
-        }
     }
     
     @objc func togglePlayPause() {
@@ -176,11 +146,5 @@ class ChallengeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDele
         coverImageView.isHidden = true
     }
     
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if touch.view == likeButton {
-            return false
-        }
-        return true
-    }
     
 }

--- a/VoQal_iOS/Views/Challenge/ChallengeView.swift
+++ b/VoQal_iOS/Views/Challenge/ChallengeView.swift
@@ -106,7 +106,7 @@ class ChallengeView: BaseView {
         firstItem.imageSize = CGSize(width: 30, height: 30)
         firstItem.action = { [weak self] item in
             self?.challengeViewController?.didTapPostChallengeBtn()
-            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
+//            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
         }
         
         let secondItem = floatingButton.addItem()
@@ -116,7 +116,7 @@ class ChallengeView: BaseView {
         secondItem.imageSize = CGSize(width: 30, height: 30)
         secondItem.action = { [weak self] item in
             self?.challengeViewController?.didTapMyPostBtn()
-            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
+//            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
         }
         
         let thirdItem = floatingButton.addItem()
@@ -126,7 +126,7 @@ class ChallengeView: BaseView {
         thirdItem.imageSize = CGSize(width: 30, height: 30)
         thirdItem.action = { [weak self] item in
             self?.challengeViewController?.didTapMyLikePostBtn()
-            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
+//            self?.challengeViewController?.temporarilyStopOrPlayPlayers(true)
         }
     }
     

--- a/VoQal_iOS/Views/Challenge/MyChallengePostView.swift
+++ b/VoQal_iOS/Views/Challenge/MyChallengePostView.swift
@@ -47,7 +47,7 @@ class MyChallengePostView: BaseView {
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
-            collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 70),
+            collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 35),
             collectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -70)
         ])
     }

--- a/VoQal_iOS/Views/MyPage/ChangeCoachView.swift
+++ b/VoQal_iOS/Views/MyPage/ChangeCoachView.swift
@@ -1,0 +1,89 @@
+//
+//  ChangeCoachView.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import UIKit
+
+class ChangeCoachView: BaseView {
+    
+    private let introLabel: UILabel = {
+        let label = UILabel()
+        label.text = "어떤 코치님으로 변경하시겠어요?"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "SUIT-Regular", size: 21)
+        label.font = UIFont.systemFont(ofSize: 21)
+        label.textAlignment = .center
+        label.textColor = UIColor.white
+        
+        return label
+    }()
+    
+    internal let coachTableView: UITableView = {
+        
+        let tableView = UITableView()
+        tableView.separatorStyle = .none
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = UIColor(named: "mainBackgroundColor")
+        
+        return tableView
+    }()
+    
+    internal let changeCoachButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "checkmark"), for: .normal)
+        button.backgroundColor = UIColor.white
+        button.tintColor = UIColor(named: "mainBackgroundColor")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = UIColor(named: "mainBackgroundColor")
+        
+        addSubViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        changeCoachButton.layer.cornerRadius = changeCoachButton.frame.height / 2
+    }
+    
+    override func addSubViews() {
+        addSubview(introLabel)
+        addSubview(coachTableView)
+        addSubview(changeCoachButton)
+    }
+    
+    override func setConstraints() {
+        NSLayoutConstraint.activate([
+            introLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            introLabel.topAnchor.constraint(equalTo: centerYAnchor, constant: -270),
+            introLabel.widthAnchor.constraint(equalToConstant: 320),
+            introLabel.heightAnchor.constraint(equalToConstant: 50),
+            
+            coachTableView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 40),
+            coachTableView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -40),
+            coachTableView.topAnchor.constraint(equalTo: introLabel.bottomAnchor, constant: 35),
+            coachTableView.heightAnchor.constraint(equalToConstant: 400),
+            
+            changeCoachButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            changeCoachButton.topAnchor.constraint(equalTo: coachTableView.bottomAnchor, constant: 20),
+            changeCoachButton.widthAnchor.constraint(equalToConstant: 45),
+            changeCoachButton.heightAnchor.constraint(equalToConstant: 45),
+        ])
+    }
+    
+    
+
+}

--- a/VoQal_iOS/Views/MyPage/EditNicknameView.swift
+++ b/VoQal_iOS/Views/MyPage/EditNicknameView.swift
@@ -1,0 +1,244 @@
+//
+//  EditProfileView.swift
+//  VoQal_iOS
+//
+//  Created by 송규섭 on 8/25/24.
+//
+
+import UIKit
+
+class EditNicknameView: BaseView, UITextFieldDelegate {
+
+    weak var editNicknameVC: EditNicknameViewController?
+    
+    var isNicknameAPICallInProgress = false
+    var isNicknameEditingInProgress = false
+    
+    internal var originalNickname: String?
+    
+    
+    private let dimmedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black
+        view.alpha = 0.7
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "mainBackgroundColor")
+        view.layer.cornerRadius = 15.0
+        view.layer.cornerCurve = .continuous
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    internal let closeButton: UIButton = {
+        let button = UIButton()
+        let configuration = UIImage.SymbolConfiguration(pointSize: 21)
+        button.tintColor = .white
+        button.setImage(UIImage(systemName: "xmark", withConfiguration: configuration), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let pageTitle: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "SUIT-SemiBold", size: 17)
+        label.textColor = .white
+        label.text = "레슨곡 설정"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    internal let nicknameField: TextFieldWithBottomBorder = {
+        let textfield = TextFieldWithBottomBorder()
+        textfield.backgroundColor = UIColor(named: "mainBackgroundColor")
+        textfield.placeholder = "닉네임을 입력해주세요."
+        textfield.translatesAutoresizingMaskIntoConstraints = false
+        
+        return textfield
+    }()
+    
+    lazy var nicknameVerifyButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = UIColor(named: "mainButtonColor")
+        button.setTitle("중복확인", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.layer.cornerRadius = 7
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    lazy var nicknameVerifyLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "SUIT-Regular", size: 13)
+        
+        return label
+    }()
+    
+    private let noticeLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "SUIT-Regular", size: 15)
+        label.textColor = .white
+        label.text = "닉네임은 공백, 특수문자를 제외하여 2~15자로 입력해주세요."
+        label.textAlignment = .center
+        label.numberOfLines = .max
+        
+        return label
+    }()
+    
+    internal let completeButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = UIColor(named: "mainButtonColor")
+        button.tintColor = .white
+        button.setTitle("완료", for: .normal)
+        button.titleLabel?.font = UIFont(name: "SUIT-Regular", size: 13)
+        button.layer.cornerRadius = 10.0
+        button.layer.cornerCurve = .continuous
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private lazy var tapGesture: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        return gesture
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addGestureRecognizer(tapGesture)
+        nicknameField.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+    
+    @objc private func dismissKeyboard() {
+        print("외부 탭")
+        endEditing(true)
+    }
+    
+    override func addSubViews() {
+        addSubview(dimmedView)
+        addSubview(contentView)
+        addSubview(closeButton)
+        contentView.addSubview(pageTitle)
+        contentView.addSubview(nicknameField)
+        contentView.addSubview(nicknameVerifyButton)
+        contentView.addSubview(nicknameVerifyLabel)
+        contentView.addSubview(completeButton)
+        contentView.addSubview(noticeLabel)
+    }
+    
+    override func setConstraints() {
+        
+        NSLayoutConstraint.activate([
+            dimmedView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            dimmedView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            dimmedView.topAnchor.constraint(equalTo: topAnchor),
+            dimmedView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            contentView.centerXAnchor.constraint(equalTo: dimmedView.centerXAnchor),
+            contentView.centerYAnchor.constraint(equalTo: dimmedView.centerYAnchor),
+            contentView.widthAnchor.constraint(equalToConstant: 300),
+            contentView.heightAnchor.constraint(equalToConstant: 320),
+            
+            closeButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -3),
+            closeButton.bottomAnchor.constraint(equalTo: contentView.topAnchor, constant: -5),
+            closeButton.widthAnchor.constraint(equalToConstant: 40),
+            closeButton.heightAnchor.constraint(equalToConstant: 40),
+            
+            pageTitle.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            pageTitle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            
+            nicknameField.topAnchor.constraint(equalTo: pageTitle.bottomAnchor, constant: 50),
+            nicknameField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25),
+            nicknameField.trailingAnchor.constraint(equalTo: nicknameVerifyButton.leadingAnchor, constant: -10),
+            nicknameField.heightAnchor.constraint(equalToConstant: 40),
+            
+            nicknameVerifyButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -25),
+            nicknameVerifyButton.topAnchor.constraint(equalTo: nicknameField.topAnchor, constant: 0),
+            nicknameVerifyButton.heightAnchor.constraint(equalToConstant: 40),
+            nicknameVerifyButton.widthAnchor.constraint(equalToConstant: 70),
+            
+            nicknameVerifyLabel.leadingAnchor.constraint(equalTo: nicknameField.leadingAnchor),
+            nicknameVerifyLabel.trailingAnchor.constraint(equalTo: nicknameField.trailingAnchor, constant: -5),
+            nicknameVerifyLabel.topAnchor.constraint(equalTo: nicknameField.bottomAnchor, constant: 5),
+            
+            noticeLabel.topAnchor.constraint(equalTo: nicknameField.bottomAnchor, constant: 40),
+            noticeLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 30),
+            noticeLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30),
+            
+            completeButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            completeButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20),
+            completeButton.widthAnchor.constraint(equalToConstant: 70),
+            completeButton.heightAnchor.constraint(equalToConstant: 35),
+            
+        ])
+    }
+    
+    func updateNicknameVerificationButton(isVerified: Bool) {
+        nicknameVerifyButton.alpha = isVerified ? 0.5 : 1.0
+        nicknameVerifyButton.setTitle(isVerified ? "수정" : "중복확인" , for: .normal)
+        nicknameField.isEnabled = isVerified ? false : true
+    }
+    
+    func updateNicknameVerifyLabel(_ verified: Bool) {
+        if verified {
+            self.nicknameVerifyLabel.textColor = UIColor(hexCode: "0A84FF", alpha: 1.0)
+            self.nicknameVerifyLabel.text = "사용 가능한 닉네임입니다."
+        }
+        else {
+            self.nicknameVerifyLabel.textColor = UIColor(hexCode: "FF3B30", alpha: 1.0)
+            self.nicknameVerifyLabel.text = "닉네임이 중복되었습니다."
+        }
+    }
+    
+    func clearNicknameVerifyLabel() {
+        self.nicknameVerifyLabel.text = ""
+    }
+    
+    // MARK: - textField Delegate 메서드 정의
+ 
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if textField == nicknameField {
+            isNicknameEditingInProgress = true
+            nicknameVerifyButton.isEnabled = false
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        print("end editing")
+        
+//        var accountErrorMessage: String = ""
+//        var basicInfoErrorMessage: String = ""
+        
+        // basicInfo 관련 텍스트필드 유효성 검증
+        
+        if textField == self.nicknameField {
+            editNicknameVC?.isNicknameVerified = false
+            
+            isNicknameEditingInProgress = false
+            if !isNicknameAPICallInProgress {
+                nicknameVerifyButton.isEnabled = true
+            }
+            if textField.text != originalNickname {
+                editNicknameVC!.isNicknameVerified = false
+                updateNicknameVerificationButton(isVerified: false)
+            }
+        }
+    }
+    
+}

--- a/VoQal_iOS/Views/MyPage/MyPageView.swift
+++ b/VoQal_iOS/Views/MyPage/MyPageView.swift
@@ -27,6 +27,17 @@ class MyPageView: BaseView {
         return label
     }()
     
+    internal let changeNicknameButton: UIButton = {
+        let button = UIButton()
+        let configuration = UIImage.SymbolConfiguration(pointSize: 15)
+        let image = UIImage(systemName: "pencil", withConfiguration: configuration)
+        button.setImage(image, for: .normal)
+        button.tintColor = .white
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
     private let coachLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -34,19 +45,6 @@ class MyPageView: BaseView {
         label.textColor = .white
         
         return label
-    }()
-    
-    private let editProfileButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("프로필 변경", for: .normal)
-        button.layer.cornerRadius = 5
-        button.layer.cornerCurve = .continuous
-        button.titleLabel?.textColor = .white
-        button.backgroundColor = UIColor(named: "mainButtonColor")
-        button.titleLabel?.font = UIFont(name: "SUIT-Medium", size: 13)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        
-        return button
     }()
     
     private let separatorView: UIView = {
@@ -70,6 +68,7 @@ class MyPageView: BaseView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        
     }
 
     required init?(coder: NSCoder) {
@@ -81,8 +80,8 @@ class MyPageView: BaseView {
         
         addSubview(nameLabel)
         addSubview(nicknameLabel)
+        addSubview(changeNicknameButton)
         addSubview(coachLabel)
-        addSubview(editProfileButton)
         addSubview(separatorView)
         addSubview(menuTableView)
     }
@@ -97,18 +96,18 @@ class MyPageView: BaseView {
             nicknameLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 10),
             nicknameLabel.bottomAnchor.constraint(equalTo: nameLabel.bottomAnchor),
             
+            changeNicknameButton.leadingAnchor.constraint(equalTo: nicknameLabel.trailingAnchor, constant: 10),
+            changeNicknameButton.centerYAnchor.constraint(equalTo: nicknameLabel.centerYAnchor),
+            changeNicknameButton.widthAnchor.constraint(equalToConstant: 20),
+            changeNicknameButton.heightAnchor.constraint(equalToConstant: 20),
+            
             coachLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 10),
             coachLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
-            
-            editProfileButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
-            editProfileButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
-            editProfileButton.heightAnchor.constraint(equalToConstant: 30),
-            editProfileButton.topAnchor.constraint(equalTo: coachLabel.bottomAnchor, constant: 20),
             
             separatorView.heightAnchor.constraint(equalToConstant: 10),
             separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            separatorView.topAnchor.constraint(equalTo: editProfileButton.bottomAnchor, constant: 20),
+            separatorView.topAnchor.constraint(equalTo: coachLabel.bottomAnchor, constant: 20),
             
             menuTableView.topAnchor.constraint(equalTo: separatorView.bottomAnchor, constant: 10),
             menuTableView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/VoQal_iOS/Views/Onboarding/RegistrationView.swift
+++ b/VoQal_iOS/Views/Onboarding/RegistrationView.swift
@@ -15,8 +15,6 @@ class RegistrationView: UIView, UITextFieldDelegate {
     var isEmailEditingInProgress = false
     var isNicknameAPICallInProgress = false
     var isNicknameEditingInProgress = false
-    let emailDispatchGroup = DispatchGroup()
-    let nicknameDispatchGroup = DispatchGroup()
     
     internal var originalEmail: String?
     internal var originalNickname: String?
@@ -460,7 +458,7 @@ class RegistrationView: UIView, UITextFieldDelegate {
         if textField == self.nicknameField {
             registrationVC?.isNicknameVerified = false
             if let nickname = nicknameField.text, !ValidationUtility.isValidNickname(nickname){
-                basicInfoErrorMessage = "- 닉네임은 공백, 특수문자를 제외하여 3~15자로 입력해주세요."
+                basicInfoErrorMessage = "- 닉네임은 공백, 특수문자를 제외하여 2~15자로 입력해주세요."
             }
             
             isNicknameEditingInProgress = false


### PR DESCRIPTION
- 닉네임 변경 부분은 completeButton, closeButton 구현 마치면 끝
- 좋아요한 챌린지 포스트엔 api 업데이트 되면 구현하도록
- 회원가입 파트에서 DispatchGroup 사용 중지(불필요하다고 느꼈음)