### PR TITLE
챌린지 수정 후 리로드 반영

### DIFF
--- a/VoQal_iOS/Controllers/Challenge/MyChallengePostViewController.swift
+++ b/VoQal_iOS/Controllers/Challenge/MyChallengePostViewController.swift
@@ -61,6 +61,12 @@ class MyChallengePostViewController: BaseViewController {
         
         let vc = EditChallengeViewController()
         vc.setValues(singer, songTitle, thumbnail, challengePostId)
+        vc.editCompletion = { [weak self] in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.fetchData()
+            }
+        }
         vc.modalPresentationStyle = .overFullScreen
         
         self.present(vc, animated: true)

--- a/VoQal_iOS/Networking/Challenge/EditChallengeManager.swift
+++ b/VoQal_iOS/Networking/Challenge/EditChallengeManager.swift
@@ -9,8 +9,8 @@ import Foundation
 import Alamofire
 
 struct EditChallengeParameter: Encodable {
-    let songTitle: String
-    let singer: String
+    let updateSongTitle: String
+    let updateSinger: String
 }
 
 struct EditChallengeManager {
@@ -23,11 +23,7 @@ struct EditChallengeManager {
     func editChallenge(thumbnail: Data?, thumbnailName: String?, songTitle: String, singer: String, fileURL: URL?, challengePostId: Int64, completion: @escaping (EditChallengeModel?) -> Void) {
         let url = "https://www.voqal.today/challenge/\(challengePostId)"
         
-        let editChallengeRequestDTO = EditChallengeParameter(songTitle: songTitle, singer: singer)
-        
-        if thumbnail == nil {
-            
-        }
+        let editChallengeRequestDTO = EditChallengeParameter(updateSongTitle: songTitle, updateSinger: singer)
         
         // JSON 데이터를 인코딩
         guard let jsonData = try? JSONEncoder().encode(editChallengeRequestDTO) else {


### PR DESCRIPTION
챌린지 수정 성공 후 내 챌린지 게시글로 돌아오면 수정 사항 반영이 안되는 점 api 재호출로 해결.