### PR TITLE
채팅 관련 커스텀 토큰 및 리스너 기능 구현

### DIFF
--- a/VoQal_iOS/Controllers/MyPage/MyPageViewController.swift
+++ b/VoQal_iOS/Controllers/MyPage/MyPageViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import MessageUI
+import FirebaseAuth
 
 protocol MyPageViewDelegate: AnyObject {
     func removeTarget()
@@ -148,6 +149,7 @@ class MyPageViewController: BaseViewController {
             print("after logout: \(UserManager.shared.userModel)")
             self.delegate?.removeTarget()
             self.resetAllNavigationStacks()
+            self.signOutFirebaseAuthentication()
             self.showLoginScreen()
         }))
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
@@ -182,6 +184,15 @@ class MyPageViewController: BaseViewController {
                     navigationController.popToRootViewController(animated: false)
                 }
             }
+        }
+    }
+    
+    private func signOutFirebaseAuthentication() {
+        do {
+            try Auth.auth().signOut()
+            print("User signed out successfully.")
+        } catch let signOutError as NSError {
+            print("Error signing out: \(signOutError.localizedDescription)")
         }
     }
     

--- a/VoQal_iOS/Controllers/Onboarding/LoginViewController.swift
+++ b/VoQal_iOS/Controllers/Onboarding/LoginViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class LoginViewController: BaseViewController {
     
@@ -112,10 +113,12 @@ class LoginViewController: BaseViewController {
                         }
                         else if result.role == "COACH" {
                             self.loginCompletion?()
+                            self.signInFirebase()
                             self.dismiss(animated: true)
                         }
                         else if result.role == "STUDENT" {
                             self.loginCompletion?()
+                            self.signInFirebase()
                             self.dismiss(animated: true)
                         }
                         
@@ -138,6 +141,24 @@ class LoginViewController: BaseViewController {
             self.present(alert, animated: true)
         }
     }
+    
+    private func signInFirebase() {
+        loginManager.fetchFirebaseCustomToken { [weak self] model in
+            guard let model = model, let self = self else {
+                print("signInFirebase - model or self is nil"); return
+            }
+            
+            if model.status == 200 {
+                Auth.auth().signIn(withCustomToken: model.firebaseCustomToken) { authResult, error in
+                    if let error = error {
+                        print("Firebase custom token authentication failed: \(error.localizedDescription)"); return
+                    }
+                    print("Firebase Authentication successful")
+                }
+            }
+        }
+    }
+    
 }
 
     extension LoginViewController: LoginViewDelegate {

--- a/VoQal_iOS/Models/Onboarding/Account/LoginData.swift
+++ b/VoQal_iOS/Models/Onboarding/Account/LoginData.swift
@@ -29,3 +29,8 @@ struct StudentStatusData: Codable {
 struct StudentStatus: Codable {
     let status: String?
 }
+
+struct FetchFirebaseCustomTokenData: Codable {
+    let firebaseCustomToken: String
+    let status: Int
+}

--- a/VoQal_iOS/Models/Onboarding/Account/LoginModel.swift
+++ b/VoQal_iOS/Models/Onboarding/Account/LoginModel.swift
@@ -24,3 +24,8 @@ struct StudentStatusModel {
     let code: String?
     let data: StudentStatus?
 }
+
+struct FetchFirebaseCustomTokenModel {
+    let firebaseCustomToken: String
+    let status: Int
+}

--- a/VoQal_iOS/Networking/Onboarding/Account/LoginManager.swift
+++ b/VoQal_iOS/Networking/Onboarding/Account/LoginManager.swift
@@ -59,4 +59,22 @@ struct LoginManager {
         }
     }
     
+    func fetchFirebaseCustomToken(completion: @escaping (FetchFirebaseCustomTokenModel?) -> Void) {
+        let url = "https://www.voqal.today/firebase-token"
+        
+        AF.request(url, method: .post, interceptor: AuthInterceptor()).responseDecodable(of: FetchFirebaseCustomTokenData.self) { response in
+            switch response.result {
+            case .success(let res):
+                print(res)
+                let status = res.status
+                let customToken = res.firebaseCustomToken
+                let model = FetchFirebaseCustomTokenModel(firebaseCustomToken: customToken, status: status)
+                completion(model)
+            case .failure(let err):
+                print(err)
+                completion(nil)
+            }
+        }
+    }
+    
 }

--- a/VoQal_iOS/Views/Cells/Chatting/ReceiverMessageCell.swift
+++ b/VoQal_iOS/Views/Cells/Chatting/ReceiverMessageCell.swift
@@ -43,7 +43,8 @@ class ReceiverMessageCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: ReceiverMessageCell.identifier)
         
-        backgroundColor = UIColor(named: "mainBackgroundColor")
+        let mainBackgroundColor = UIColor(named: "mainBackgroundColor")
+        backgroundColor = mainBackgroundColor
         
         selectionStyle = .none
         addSubViews()


### PR DESCRIPTION
- 로그인 시 jwt를 통한 파이어베이스 커스텀 토큰 발급 후 이를 이용해 인증.
- 인증 후 채팅방 입장 시 리스너 추가 구현. (Firestore 보안 규칙 업데이트)