### PR TITLE
챌린지 셀 이동 간 버그 해결

### DIFF
--- a/VoQal_iOS/Controllers/Challenge/MyChallengePostViewController.swift
+++ b/VoQal_iOS/Controllers/Challenge/MyChallengePostViewController.swift
@@ -191,7 +191,12 @@ extension MyChallengePostViewController: UICollectionViewDelegate, UICollectionV
     
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         if let cell = cell as? MyChallengePostCollectionViewCell {
-            cell.togglePlayPause() // 셀이 사라지면 자동으로 일시정지
+            if let player = cell.player {
+                cell.player?.pause()
+            }
+            else {
+                print("player is nil")
+            }
         }
     }
 }

--- a/VoQal_iOS/Controllers/Challenge/MyLikePostChallengeViewController.swift
+++ b/VoQal_iOS/Controllers/Challenge/MyLikePostChallengeViewController.swift
@@ -202,7 +202,12 @@ extension MyLikePostChallengeViewController: UICollectionViewDelegate, UICollect
     
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         if let cell = cell as? MyLikePostCollectionViewCell {
-            cell.togglePlayPause() // 셀이 사라지면 자동으로 일시정지
+            if let player = cell.player {
+                cell.player?.pause()
+            }
+            else {
+                print("player is nil")
+            }
         }
     }
 }


### PR DESCRIPTION
- 내가 좋아요 한 챌린지 게시물, 내 게시물들의 셀 간 이동 시 이전 셀의 음악이 플레이되는 현상 해결